### PR TITLE
build(deps): bump tar resolution to >=7.5.8 (CVE-2026-26960)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@actions/core": "^1.11.1"
   },
   "resolutions": {
-    "tar": ">=7.5.7"
+    "tar": ">=7.5.8"
   },
   "devDependencies": {
     "@types/node": "^20.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2308,16 +2308,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:>=7.5.7":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+"tar@npm:>=7.5.8":
+  version: 7.5.11
+  resolution: "tar@npm:7.5.11"
   dependencies:
     "@isaacs/fs-minipass": ^4.0.0
     chownr: ^3.0.0
     minipass: ^7.1.2
     minizlib: ^3.1.0
     yallist: ^5.0.0
-  checksum: 82fa04804b6cae4c0b46b84e97a08c39e1c17bb959350baa32d139bcf5e1fc7ebc3ceb72465dd3e2e311992386ecc13599a257d5672158490ceb9464146d5573
+  checksum: 7f6785a85dd571b88985e493ec86f692962cbfa7b4017961fddfd2241e0ff3bcd89ed347f4c02b5433aa22b30cca5566e8711543df054fda8fd12425f505378f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps the `tar` yarn resolution override from `>=7.5.7` to `>=7.5.8`
- Lockfile now resolves to `tar@7.5.11`
- Fixes Dependabot alert #16

## Security context

**CVE-2026-26960 / GHSA-83g3-92jg-28cx** — High severity (CVSS 7.1)

Arbitrary file read/write via hardlink target escape through symlink chain in `node-tar` extraction. Fixed in `tar@7.5.8`.

The action itself does not call `tar.extract()` at runtime, so exploitability is low. However, the vulnerable package was present as a transitive dependency via `cacache` and `node-gyp` (build toolchain), and the previous resolution pin (`>=7.5.7`) missed the fix by one patch version.

## Test plan

- [x] `yarn install` completes successfully
- [x] `yarn.lock` resolves `tar` to `7.5.11`
- [ ] CI build passes

Closes #16 (Dependabot alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)